### PR TITLE
Fixing some small mistakes in problem description

### DIFF
--- a/geometry/wingGeometry.py
+++ b/geometry/wingGeometry.py
@@ -57,9 +57,7 @@ TECoords[:, verticalIndex] = sectionVerticalOffset - sectionChord * np.sin(np.de
 rootChord = sectionChord[0]
 tipChord = sectionChord[1]
 planformArea = semiSpan * (rootChord + tipChord) * 0.5
-meanAerodynamicChord = planformArea * (
-    (2.0 / 3.0) * (rootChord + tipChord - rootChord * tipChord / (rootChord + tipChord))
-)
+meanAerodynamicChord = (2.0 / 3.0) * (rootChord + tipChord - rootChord * tipChord / (rootChord + tipChord))
 aspectRatio = 2 * (semiSpan**2) / planformArea
 taperRatio = tipChord / rootChord
 


### PR DESCRIPTION
Fixing a few small issues:

- In section 2.3.3, the problem description mistakenly said that the maneuvers should be performed at the takeoff gross mass, it should instead be the landing gross mass, as is listed in tables 5 and 7.
- The MAC calculation in `wingGeometry.py` was incorrectly multiplying by the wing planform area, this has been fixed and the MAC value in table 5 corrected.

Thanks to @fmamitrotta for pointing out these mistakes.